### PR TITLE
Simplify logos and license notice

### DIFF
--- a/Numpy-1_Arrays_Dtypes_Shapes.ipynb
+++ b/Numpy-1_Arrays_Dtypes_Shapes.ipynb
@@ -10,9 +10,11 @@
     "tags": []
    },
    "source": [
-    "| <img src=\"img/Erudio-logo.png\" alt=\"Erudio logo\" width=\"100\"/>| | Elevate Your Potential with the Power of Artificial Intelligence |\n",
-    "|---:|---:|:---|\n",
-    "| <div style=\"width:600px\"><img src=\"img/numpylogo.svg\" alt=\"NumPy logo\" width=\"200\"/></div>| <div style=\"width:200px; font-size:20px\">Lesson 1:</div> | <div style=\"width:400px; font-size:20px\">Numpy Fundamentals, dtypes and shapes</div>|"
+    "![Erudio logo](img/Erudio-logo.png)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "![NumPy logo](img/numpylogo.svg)"
    ]
   },
   {
@@ -1245,8 +1247,9 @@
     "tags": []
    },
    "source": [
-    "| | Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)  by the authors|\n",
-    "|---|---|"
+    "---\n",
+    "\n",
+    "Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)  by the authors"
    ]
   }
  ],

--- a/Numpy-2a_Slicing.ipynb
+++ b/Numpy-2a_Slicing.ipynb
@@ -10,9 +10,11 @@
     "tags": []
    },
    "source": [
-    "| <img src=\"img/Erudio-logo.png\" alt=\"Erudio logo\" width=\"100\"/>| | Elevate Your Potential with the Power of Artificial Intelligence |\n",
-    "|---:|---:|:---|\n",
-    "| <div style=\"width:600px\"><img src=\"img/numpylogo.svg\" alt=\"NumPy logo\" width=\"200\"/></div>| <div style=\"width:200px; font-size:20px\">Lesson 2a:</div> | <div style=\"width:400px; font-size:20px\">Selecting and modifying data, slicing</div>|"
+    "![Erudio logo](img/Erudio-logo.png)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "![NumPy logo](img/numpylogo.svg)"
    ]
   },
   {
@@ -728,8 +730,9 @@
     "tags": []
    },
    "source": [
-    "| | Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)  by the authors|\n",
-    "|---|---|"
+    "---\n",
+    "\n",
+    "Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) by the authors"
    ]
   }
  ],

--- a/Numpy-2b_Vectorization.ipynb
+++ b/Numpy-2b_Vectorization.ipynb
@@ -10,9 +10,11 @@
     "tags": []
    },
    "source": [
-    "| <img src=\"img/Erudio-logo.png\" alt=\"Erudio logo\" width=\"100\"/>| | Elevate Your Potential with the Power of Artificial Intelligence |\n",
-    "|---:|---:|:---|\n",
-    "| <div style=\"width:600px\"><img src=\"img/numpylogo.svg\" alt=\"NumPy logo\" width=\"200\"/></div>| <div style=\"width:200px; font-size:20px\">Lesson 2b:</div> | <div style=\"width:400px; font-size:20px\">Selecting and modifying data, vectorization</div>|"
+    "![Erudio logo](img/Erudio-logo.png)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "![NumPy logo](img/numpylogo.svg)"
    ]
   },
   {
@@ -902,8 +904,9 @@
     "tags": []
    },
    "source": [
-    "| | Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)  by the authors|\n",
-    "|---|---|"
+    "---\n",
+    "\n",
+    "Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) by the authors"
    ]
   }
  ],

--- a/Numpy-3_Fancy_Selection.ipynb
+++ b/Numpy-3_Fancy_Selection.ipynb
@@ -10,9 +10,11 @@
     "tags": []
    },
    "source": [
-    "| <img src=\"img/Erudio-logo.png\" alt=\"Erudio logo\" width=\"100\"/>| | Elevate Your Potential with the Power of Artificial Intelligence |\n",
-    "|---:|---:|:---|\n",
-    "| <div style=\"width:600px\"><img src=\"img/numpylogo.svg\" alt=\"NumPy logo\" width=\"200\"/></div>| <div style=\"width:200px; font-size:20px\">Lesson 3:</div> | <div style=\"width:400px; font-size:20px\">Boolean and filtered selection</div>|"
+    "![Erudio logo](img/Erudio-logo.png)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "![NumPy logo](img/numpylogo.svg)"
    ]
   },
   {
@@ -903,8 +905,9 @@
     "tags": []
    },
    "source": [
-    "| | Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)  by the authors|\n",
-    "|---|---|"
+    "---\n",
+    "\n",
+    "Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) by the authors"
    ]
   }
  ],

--- a/Numpy-4_Shaping_Broadcasting.ipynb
+++ b/Numpy-4_Shaping_Broadcasting.ipynb
@@ -10,9 +10,11 @@
     "tags": []
    },
    "source": [
-    "| <img src=\"img/Erudio-logo.png\" alt=\"Erudio logo\" width=\"100\"/>| | Elevate Your Potential with the Power of Artificial Intelligence |\n",
-    "|---:|---:|:---|\n",
-    "| <div style=\"width:600px\"><img src=\"img/numpylogo.svg\" alt=\"NumPy logo\" width=\"200\"/></div>| <div style=\"width:200px; font-size:20px\">Lesson 4:</div> | <div style=\"width:400px; font-size:20px\">Shaping and broadcasting</div>|"
+    "![Erudio logo](img/Erudio-logo.png)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "![NumPy logo](img/numpylogo.svg)"
    ]
   },
   {
@@ -883,8 +885,9 @@
     "tags": []
    },
    "source": [
-    "| | Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)  by the authors|\n",
-    "|---|---|"
+    "---\n",
+    "\n",
+    "Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) by the authors"
    ]
   }
  ],

--- a/Numpy-5_Join_Stack_Split.ipynb
+++ b/Numpy-5_Join_Stack_Split.ipynb
@@ -10,9 +10,11 @@
     "tags": []
    },
    "source": [
-    "| <img src=\"img/Erudio-logo.png\" alt=\"Erudio logo\" width=\"100\"/>| | Elevate Your Potential with the Power of Artificial Intelligence |\n",
-    "|---:|---:|:---|\n",
-    "| <div style=\"width:600px\"><img src=\"img/numpylogo.svg\" alt=\"NumPy logo\" width=\"200\"/></div>| <div style=\"width:200px; font-size:20px\">Lesson 5:</div> | <div style=\"width:400px; font-size:20px\">Joining, Stacking, and Spliting Arrays</div>|"
+    "![Erudio logo](img/Erudio-logo.png)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "![NumPy logo](img/numpylogo.svg)"
    ]
   },
   {
@@ -779,8 +781,9 @@
     "tags": []
    },
    "source": [
-    "| | Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)  by the authors|\n",
-    "|---|---|"
+    "---\n",
+    "\n",
+    "Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) by the authors"
    ]
   }
  ],

--- a/Numpy-6_Advanced.ipynb
+++ b/Numpy-6_Advanced.ipynb
@@ -10,9 +10,11 @@
     "tags": []
    },
    "source": [
-    "| <img src=\"img/Erudio-logo.png\" alt=\"Erudio logo\" width=\"100\"/>| | Elevate Your Potential with the Power of Artificial Intelligence |\n",
-    "|---:|---:|:---|\n",
-    "| <div style=\"width:600px\"><img src=\"img/numpylogo.svg\" alt=\"NumPy logo\" width=\"200\"/></div>| <div style=\"width:200px; font-size:20px\">Lesson 6:</div> | <div style=\"width:400px; font-size:20px\">Miscellaneous and Advanced Topics</div>|"
+    "![Erudio logo](img/Erudio-logo.png)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "![NumPy logo](img/numpylogo.svg)"
    ]
   },
   {
@@ -723,8 +725,9 @@
     "tags": []
    },
    "source": [
-    "| | Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/)  by the authors|\n",
-    "|---|---|"
+    "---\n",
+    "\n",
+    "Materials licensed under [CC BY-NC-ND 4.0](https://creativecommons.org/licenses/by-nc-nd/4.0/) by the authors"
    ]
   }
  ],

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: erudio-numpy
+name: erudio.numpy
 channels:
   - conda-forge
   - defaults


### PR DESCRIPTION
@map0logo I just took out the Markdown table elements that made the logos and notices small.  Big and bold at top (and very simple Markdown) seems better to me.

The first H1 header is generally close to the title of the lesson already, so no need to replicate that in header elements.