### PR TITLE
Remove jupytext configuration

### DIFF
--- a/jupytext.toml
+++ b/jupytext.toml
@@ -1,1 +1,0 @@
-formats = "ipynb,py:light,qmd"


### PR DESCRIPTION
With Jupytext, if markdown or source formats are saved, there is a great risk of erasing slide information on cells. For now is better to export to desired formats.